### PR TITLE
Make `schemaGeneratorConfigBuilder` configurable

### DIFF
--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerUIPluginConfig.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerUIPluginConfig.kt
@@ -1,5 +1,10 @@
 package io.github.smiley4.ktorswaggerui
 
+import com.github.victools.jsonschema.generator.Option
+import com.github.victools.jsonschema.generator.OptionPreset
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
+import com.github.victools.jsonschema.generator.SchemaVersion
+import com.github.victools.jsonschema.module.jackson.JacksonModule
 import io.github.smiley4.ktorswaggerui.dsl.CustomSchemas
 import io.github.smiley4.ktorswaggerui.dsl.OpenApiDslMarker
 import io.github.smiley4.ktorswaggerui.dsl.OpenApiInfo
@@ -141,5 +146,12 @@ class SwaggerUIPluginConfig {
     }
 
     fun getCustomSchemas() = customSchemas
+
+    var schemaGeneratorConfigBuilder: SchemaGeneratorConfigBuilder = SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
+        .with(JacksonModule())
+        .without(Option.DEFINITIONS_FOR_ALL_OBJECTS)
+        .with(Option.INLINE_ALL_SCHEMAS)
+        .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
+        .with(Option.ALLOF_CLEANUP_AT_THE_END)
 
 }

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/OApiJsonSchemaBuilder.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/OApiJsonSchemaBuilder.kt
@@ -2,12 +2,7 @@ package io.github.smiley4.ktorswaggerui.specbuilder
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.github.victools.jsonschema.generator.Option
-import com.github.victools.jsonschema.generator.OptionPreset
 import com.github.victools.jsonschema.generator.SchemaGenerator
-import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
-import com.github.victools.jsonschema.generator.SchemaVersion
-import com.github.victools.jsonschema.module.jackson.JacksonModule
 import io.github.smiley4.ktorswaggerui.SwaggerUIPluginConfig
 import io.swagger.v3.oas.models.media.Schema
 import java.lang.reflect.Type
@@ -69,18 +64,12 @@ class OApiJsonSchemaBuilder {
                 return ObjectMapper().readTree(jsonSchema) as ObjectNode
             }
         }
-        return generateJsonSchema(type)
+        return generateJsonSchema(type, config)
     }
 
-    private fun generateJsonSchema(type: Type): ObjectNode {
-        val config = SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
-            .with(JacksonModule())
-            .without(Option.DEFINITIONS_FOR_ALL_OBJECTS)
-            .with(Option.INLINE_ALL_SCHEMAS)
-            .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
-            .with(Option.ALLOF_CLEANUP_AT_THE_END)
-            .build()
-        return SchemaGenerator(config).generateSchema(type)
+    private fun generateJsonSchema(type: Type, config: SwaggerUIPluginConfig): ObjectNode {
+        val generatorConfig = config.schemaGeneratorConfigBuilder.build()
+        return SchemaGenerator(generatorConfig).generateSchema(type)
     }
 
 }


### PR DESCRIPTION
I need to add [victools/jsonschema-module-swagger-2](https://github.com/victools/jsonschema-generator/blob/main/jsonschema-module-swagger-2) to SchemaGeneratorConfigBuilder. This PR would allow me to extend it or swap it altogether.

```
install(SwaggerUI) {
    ...
    schemaGeneratorConfigBuilder.with(Swagger2Module())
}
```

or 

```
install(SwaggerUI) {
    ...
    schemaGeneratorConfigBuilder = SchemaGeneratorConfigBuilder...
}
```