### PR TITLE
Fix #16 - put operationsSorter as string, instead of plainText in JavaScript object

### DIFF
--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerController.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerController.kt
@@ -33,7 +33,8 @@ class SwaggerController(
         val propValidatorUrl = swaggerUiConfig.getSpecValidatorUrl()?.let { "validatorUrl: \"$it\"" } ?: "validatorUrl: false"
         val propDisplayOperationId = "displayOperationId: ${swaggerUiConfig.displayOperationId}"
         val propFilter = "filter: ${swaggerUiConfig.showTagFilterInput}"
-        val propSort = "operationsSorter: " + if (swaggerUiConfig.sort == SwaggerUiSort.NONE) "undefined" else swaggerUiConfig.sort.value
+        val propSort = "operationsSorter: " + if (swaggerUiConfig.sort == SwaggerUiSort.NONE) "undefined" else
+            "\"${swaggerUiConfig.sort.value}\""
         val propSyntaxHighlight = "syntaxHighlight: { theme: \"${swaggerUiConfig.syntaxHighlight.value}\" }"
         // see https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md for reference
         val content = """


### PR DESCRIPTION
#16 - Fixed operationsSorter value

<img width="301" alt="image" src="https://user-images.githubusercontent.com/49353043/212557128-0ab56552-6042-4f14-bd01-8bbd66d4c385.png">