### PR TITLE
Use simpleName instead of canonicalName as identifying name for type

### DIFF
--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerUIPluginConfig.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerUIPluginConfig.kt
@@ -71,6 +71,10 @@ class SwaggerUIPluginConfig {
 
     private var swaggerUI = SwaggerUI()
 
+    /**
+     * Whether to use simple instead of canonical name for component object references
+     */
+    val simpleNameObjectRefs: Boolean = false
 
     /**
      * Swagger-UI configuration
@@ -150,11 +154,12 @@ class SwaggerUIPluginConfig {
     /**
      * Customize or replace the configuration-builder for the json-schema-generator (see https://victools.github.io/jsonschema-generator/#generator-options for more information)
      */
-    var schemaGeneratorConfigBuilder: SchemaGeneratorConfigBuilder = SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
-        .with(JacksonModule())
-        .without(Option.DEFINITIONS_FOR_ALL_OBJECTS)
-        .with(Option.INLINE_ALL_SCHEMAS)
-        .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
-        .with(Option.ALLOF_CLEANUP_AT_THE_END)
+    var schemaGeneratorConfigBuilder: SchemaGeneratorConfigBuilder =
+        SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
+            .with(JacksonModule())
+            .without(Option.DEFINITIONS_FOR_ALL_OBJECTS)
+            .with(Option.INLINE_ALL_SCHEMAS)
+            .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
+            .with(Option.ALLOF_CLEANUP_AT_THE_END)
 
 }

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerUIPluginConfig.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerUIPluginConfig.kt
@@ -72,9 +72,9 @@ class SwaggerUIPluginConfig {
     private var swaggerUI = SwaggerUI()
 
     /**
-     * Whether to use simple instead of canonical name for component object references
+     * Whether to use canonical instead of simple name for component object references
      */
-    val simpleNameObjectRefs: Boolean = false
+    val canonicalNameObjectRefs: Boolean = false
 
     /**
      * Swagger-UI configuration

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/ApiSpecBuilder.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/ApiSpecBuilder.kt
@@ -21,7 +21,7 @@ class ApiSpecBuilder {
         val componentCtx = ComponentsContext(
             config.schemasInComponentSection, mutableMapOf(),
             config.examplesInComponentSection, mutableMapOf(),
-            config.simpleNameObjectRefs
+            config.canonicalNameObjectRefs
         )
         val openAPI = OpenAPI().apply {
             info = infoBuilder.build(config.getInfo())

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/ApiSpecBuilder.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/ApiSpecBuilder.kt
@@ -20,7 +20,8 @@ class ApiSpecBuilder {
     fun build(application: Application, config: SwaggerUIPluginConfig): String {
         val componentCtx = ComponentsContext(
             config.schemasInComponentSection, mutableMapOf(),
-            config.examplesInComponentSection, mutableMapOf()
+            config.examplesInComponentSection, mutableMapOf(),
+            config.simpleNameObjectRefs
         )
         val openAPI = OpenAPI().apply {
             info = infoBuilder.build(config.getInfo())

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/ComponentsContext.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/ComponentsContext.kt
@@ -14,7 +14,7 @@ data class ComponentsContext(
     val schemas: MutableMap<String, Schema<*>>,
     val examplesInComponents: Boolean,
     val examples: MutableMap<String, OpenApiExample>,
-    val simpleNameObjectRefs: Boolean
+    val canonicalNameObjectRefs: Boolean
 ) {
 
     companion object {
@@ -87,7 +87,7 @@ data class ComponentsContext(
 
     private fun getIdentifyingName(type: Type): String {
         return when (type) {
-            is Class<*> -> if (simpleNameObjectRefs) type.simpleName else type.canonicalName
+            is Class<*> -> if (canonicalNameObjectRefs) type.canonicalName else type.simpleName
             is ParameterizedType -> getIdentifyingName(type.rawType) + "<" + getIdentifyingName(type.actualTypeArguments.first()) + ">"
             is WildcardType -> getIdentifyingName(type.upperBounds.first())
             else -> throw Exception("Could not get identifying name from $type")

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/ComponentsContext.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/ComponentsContext.kt
@@ -13,11 +13,12 @@ data class ComponentsContext(
     val schemasInComponents: Boolean,
     val schemas: MutableMap<String, Schema<*>>,
     val examplesInComponents: Boolean,
-    val examples: MutableMap<String, OpenApiExample>
+    val examples: MutableMap<String, OpenApiExample>,
+    val simpleNameObjectRefs: Boolean
 ) {
 
     companion object {
-        val NOOP = ComponentsContext(false, mutableMapOf(), false, mutableMapOf())
+        val NOOP = ComponentsContext(false, mutableMapOf(), false, mutableMapOf(), false)
     }
 
 
@@ -36,9 +37,11 @@ data class ComponentsContext(
                         is WildcardType -> {
                             addSchema(actualTypeArgument.upperBounds.first(), schema.items)
                         }
+
                         else -> throw Exception("Could not add array-schema to components ($type)")
                     }
                 }
+
                 else -> throw Exception("Could not add array-schema to components ($type)")
             }
             return Schema<Any>().apply {
@@ -84,7 +87,7 @@ data class ComponentsContext(
 
     private fun getIdentifyingName(type: Type): String {
         return when (type) {
-            is Class<*> -> type.canonicalName
+            is Class<*> -> if (simpleNameObjectRefs) type.simpleName else type.canonicalName
             is ParameterizedType -> getIdentifyingName(type.rawType) + "<" + getIdentifyingName(type.actualTypeArguments.first()) + ">"
             is WildcardType -> getIdentifyingName(type.upperBounds.first())
             else -> throw Exception("Could not get identifying name from $type")

--- a/src/test/kotlin/io/github/smiley4/ktorswaggerui/tests/ComponentsObjectTest.kt
+++ b/src/test/kotlin/io/github/smiley4/ktorswaggerui/tests/ComponentsObjectTest.kt
@@ -74,13 +74,13 @@ class ComponentsObjectTest : StringSpec({
         buildSchema(ComponentsTestClass1::class, context).let {
             it.type.shouldBeNull()
             it.properties.shouldBeNull()
-            it.`$ref` shouldBe "#/components/schemas/io.github.smiley4.ktorswaggerui.tests.ComponentsObjectTest.Companion.ComponentsTestClass1"
+            it.`$ref` shouldBe "#/components/schemas/ComponentsTestClass1"
         }
 
         buildSchema(ComponentsTestClass2::class, context).let {
             it.type.shouldBeNull()
             it.properties.shouldBeNull()
-            it.`$ref` shouldBe "#/components/schemas/io.github.smiley4.ktorswaggerui.tests.ComponentsObjectTest.Companion.ComponentsTestClass2"
+            it.`$ref` shouldBe "#/components/schemas/ComponentsTestClass2"
         }
 
         buildSchema(Array<ComponentsTestClass2>::class, context).let {
@@ -89,7 +89,7 @@ class ComponentsObjectTest : StringSpec({
             it.`$ref`.shouldBeNull()
             it.items.shouldNotBeNull()
             it.items.type.shouldBeNull()
-            it.items.`$ref` shouldBe "#/components/schemas/io.github.smiley4.ktorswaggerui.tests.ComponentsObjectTest.Companion.ComponentsTestClass2"
+            it.items.`$ref` shouldBe "#/components/schemas/ComponentsTestClass2"
         }
 
         buildExample("Example1", ComponentsTestClass1("test1", true), context).let {
@@ -110,15 +110,15 @@ class ComponentsObjectTest : StringSpec({
         buildComponentsObject(context).let {
             it.schemas shouldHaveSize 2
             it.schemas.keys shouldContainExactlyInAnyOrder listOf(
-                "io.github.smiley4.ktorswaggerui.tests.ComponentsObjectTest.Companion.ComponentsTestClass1",
-                "io.github.smiley4.ktorswaggerui.tests.ComponentsObjectTest.Companion.ComponentsTestClass2"
+                "ComponentsTestClass1",
+                "ComponentsTestClass2"
             )
-            it.schemas["io.github.smiley4.ktorswaggerui.tests.ComponentsObjectTest.Companion.ComponentsTestClass1"]!!.let { schema ->
+            it.schemas["ComponentsTestClass1"]!!.let { schema ->
                 schema.type shouldBe "object"
                 schema.properties shouldHaveSize 2
                 schema.`$ref`.shouldBeNull()
             }
-            it.schemas["io.github.smiley4.ktorswaggerui.tests.ComponentsObjectTest.Companion.ComponentsTestClass2"]!!.let { schema ->
+            it.schemas["ComponentsTestClass2"]!!.let { schema ->
                 schema.type shouldBe "object"
                 schema.properties shouldHaveSize 2
                 schema.`$ref`.shouldBeNull()
@@ -197,11 +197,11 @@ class ComponentsObjectTest : StringSpec({
         }
     }
 
-    "test schemas in component section using simple name object refs" {
+    "test schemas in component section using canonical name object refs" {
         val context = ComponentsContext(true, mutableMapOf(), false, mutableMapOf(), true)
 
         buildSchema(ComponentsTestClass1::class, context).let {
-            it.`$ref` shouldBe "#/components/schemas/ComponentsTestClass1"
+            it.`$ref` shouldBe "#/components/schemas/io.github.smiley4.ktorswaggerui.tests.ComponentsObjectTest.Companion.ComponentsTestClass1"
         }
     }
 

--- a/src/test/kotlin/io/github/smiley4/ktorswaggerui/tests/ComponentsObjectTest.kt
+++ b/src/test/kotlin/io/github/smiley4/ktorswaggerui/tests/ComponentsObjectTest.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.KClass
 class ComponentsObjectTest : StringSpec({
 
     "test nothing in components section" {
-        val context = ComponentsContext(false, mutableMapOf(), false, mutableMapOf())
+        val context = ComponentsContext(false, mutableMapOf(), false, mutableMapOf(), false)
 
         buildSchema(ComponentsTestClass1::class, context).let {
             it.type shouldBe "object"
@@ -69,7 +69,7 @@ class ComponentsObjectTest : StringSpec({
     }
 
     "test schemas in components section" {
-        val context = ComponentsContext(true, mutableMapOf(), false, mutableMapOf())
+        val context = ComponentsContext(true, mutableMapOf(), false, mutableMapOf(), false)
 
         buildSchema(ComponentsTestClass1::class, context).let {
             it.type.shouldBeNull()
@@ -136,7 +136,7 @@ class ComponentsObjectTest : StringSpec({
     }
 
     "test examples in components section" {
-        val context = ComponentsContext(false, mutableMapOf(), true, mutableMapOf())
+        val context = ComponentsContext(false, mutableMapOf(), true, mutableMapOf(), false)
 
         buildSchema(ComponentsTestClass1::class, context).let {
             it.type shouldBe "object"
@@ -194,6 +194,14 @@ class ComponentsObjectTest : StringSpec({
             it.links.shouldBeNull()
             it.callbacks.shouldBeNull()
             it.extensions.shouldBeNull()
+        }
+    }
+
+    "test schemas in component section using simple name object refs" {
+        val context = ComponentsContext(true, mutableMapOf(), false, mutableMapOf(), true)
+
+        buildSchema(ComponentsTestClass1::class, context).let {
+            it.`$ref` shouldBe "#/components/schemas/ComponentsTestClass1"
         }
     }
 

--- a/src/test/kotlin/io/github/smiley4/ktorswaggerui/tests/ContentObjectTest.kt
+++ b/src/test/kotlin/io/github/smiley4/ktorswaggerui/tests/ContentObjectTest.kt
@@ -116,7 +116,7 @@ class ContentObjectTest : StringSpec({
     }
 
     "test content object with custom (remote) json-schema and components-section enabled" {
-        val content = buildCustomContentObject("remote", ComponentsContext(true, mutableMapOf(), true, mutableMapOf()))
+        val content = buildCustomContentObject("remote", ComponentsContext(true, mutableMapOf(), true, mutableMapOf(), false))
         content shouldBeContent {
             addMediaType(ContentType.Application.Json.toString(), MediaType().apply {
                 schema = Schema<Any>().apply {
@@ -147,7 +147,7 @@ class ContentObjectTest : StringSpec({
     }
 
     "test content object with custom json-schema and components-section enabled" {
-        val content = buildCustomContentObject("custom", ComponentsContext(true, mutableMapOf(), true, mutableMapOf()))
+        val content = buildCustomContentObject("custom", ComponentsContext(true, mutableMapOf(), true, mutableMapOf(), false))
         content shouldBeContent {
             addMediaType(ContentType.Application.Json.toString(), MediaType().apply {
                 schema = Schema<Any>().apply {

--- a/src/test/kotlin/io/github/smiley4/ktorswaggerui/tests/ExampleObjectTest.kt
+++ b/src/test/kotlin/io/github/smiley4/ktorswaggerui/tests/ExampleObjectTest.kt
@@ -29,7 +29,7 @@ class ExampleObjectTest : StringSpec({
     }
 
     "test referencing example in components" {
-        val componentsContext = ComponentsContext(false, mutableMapOf(), true, mutableMapOf())
+        val componentsContext = ComponentsContext(false, mutableMapOf(), true, mutableMapOf(), false)
         val exampleValue = ExampleTestClass("TestText", true)
         val example = buildExampleObject("TestExample", exampleValue, componentsContext) {
             summary = "Test Summary"


### PR DESCRIPTION
Changing head branch for this PR. See original here #14.
Canonical name can now be configured to be used as identifier for object types if needed, with Simple name as default.