### PR TITLE
added property description in schema and swagger annotation support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     val jsonSchemaGeneratorVersion = "4.28.0"
     implementation("com.github.victools:jsonschema-generator:$jsonSchemaGeneratorVersion")
     implementation("com.github.victools:jsonschema-module-jackson:$jsonSchemaGeneratorVersion")
+    implementation("com.github.victools:jsonschema-module-swagger-2:$jsonSchemaGeneratorVersion")
 
     val kotlinLoggingVersion = "2.1.23"
     implementation("io.github.microutils:kotlin-logging-jvm:$kotlinLoggingVersion")

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerUIPluginConfig.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerUIPluginConfig.kt
@@ -5,6 +5,7 @@ import com.github.victools.jsonschema.generator.OptionPreset
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
 import com.github.victools.jsonschema.generator.SchemaVersion
 import com.github.victools.jsonschema.module.jackson.JacksonModule
+import com.github.victools.jsonschema.module.swagger2.Swagger2Module
 import io.github.smiley4.ktorswaggerui.dsl.CustomSchemas
 import io.github.smiley4.ktorswaggerui.dsl.OpenApiDslMarker
 import io.github.smiley4.ktorswaggerui.dsl.OpenApiInfo
@@ -161,6 +162,7 @@ class SwaggerUIPluginConfig {
             .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
             .with(Option.ALLOF_CLEANUP_AT_THE_END)
             .with(Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES)
+            .with(Swagger2Module())
 
 
     /**

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/JsonToOpenApiSchemaConverter.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/specbuilder/JsonToOpenApiSchemaConverter.kt
@@ -11,6 +11,7 @@ class JsonToOpenApiSchemaConverter {
 
     fun toSchema(node: JsonNode): Schema<Any> {
         return Schema<Any>().apply {
+            node["description"]?.let { this.description = it.asText() }
             node["\$schema"]?.let { this.`$schema` = it.asText() }
             node["type"]?.let { this.type = it.asText() }
             node["format"]?.let { this.format = it.asText() }


### PR DESCRIPTION
Hello! As I wrote here https://github.com/SMILEY4/ktor-swagger-ui/issues/34 I wanted to have support for swagger annotations and field descriptions. They were lost at the stage of generating the json scheme, although it supports them, but with an additional module. Look please