### PR TITLE
Fix getSimpleTypeName on SchemaDefinition. E.g. handling of List<*>

### DIFF
--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/SchemaType.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/SchemaType.kt
@@ -17,10 +17,9 @@ fun SchemaType.getTypeName() = this.toString()
 fun SchemaType.getSimpleTypeName(): String {
     val rawName = getTypeName()
     if(rawName.contains("<") || rawName.contains(">")) {
-        return rawName
-    } else {
         return (this.classifier as KClass<*>).simpleName ?: rawName
     }
+    return rawName
 }
 
 fun KClass<*>.asSchemaType() = this.starProjectedType


### PR DESCRIPTION
Hi all,

I hope this message finds you well. I wanted to bring your attention to a bug that was introduced in version 2.0.0, which affects the functionality when returning a List, for example.

During the generation process, the schema name is resolved as List<*>, resulting in the following representation:

```
        "200" : {
          "description" : "",
          "headers" : { },
          "content" : {
            "application/json" : {
              "schema" : {
                "type" : "array",
							
                "items" : {
                  "$ref" : "#/components/schemas/kotlin.collections.List<de.example.Cat>"
                }
              }
            }
          }
        }
```

However, the expected behavior, as seen in version 1.*, should be:

```
        "200" : {
          "description" : "",
          "headers" : { },
          "content" : {
            "application/json" : {
              "schema" : {
                "type" : "array",
							
                "items" : {
                  "$ref" : "#/components/schemas/de.example.Cat"
                }
              }
            }
          }
        }
```


This Pull Request addresses this issue and fixes the bug. Please let me know if you have any questions or require further information.