### PR TITLE
add rootHostPath as configuration option

### DIFF
--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerRouting.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/SwaggerRouting.kt
@@ -33,7 +33,7 @@ class SwaggerRouting(
 
     private fun getApiSpecUrl(appConfig: ApplicationConfig): String {
         val rootPath = appConfig.propertyOrNull("ktor.deployment.rootPath")?.getString()?.let { "/${dropSlashes(it)}" } ?: ""
-        return "$rootPath/${dropSlashes(swaggerUiConfig.swaggerUrl)}/api.json"
+        return "$rootPath${swaggerUiConfig.rootHostPath}/${dropSlashes(swaggerUiConfig.swaggerUrl)}/api.json"
     }
 
     private fun dropSlashes(str: String): String {
@@ -54,7 +54,7 @@ class SwaggerRouting(
         app.routing {
             if (forwardRoot) {
                 get("/") {
-                    call.respondRedirect("$swaggerUrl/index.html")
+                    call.respondRedirect("${swaggerUiConfig.rootHostPath}/${dropSlashes(swaggerUrl)}/index.html")
                 }
             }
             if (authentication == null) {
@@ -71,7 +71,7 @@ class SwaggerRouting(
         val swaggerUrl = swaggerUiConfig.swaggerUrl
         route(swaggerUrl) {
             get {
-                call.respondRedirect("$swaggerUrl/index.html")
+                call.respondRedirect("${swaggerUiConfig.rootHostPath}/${dropSlashes(swaggerUrl)}/index.html")
             }
             get("api.json") {
                 controller.serveOpenApiSpec(call)

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/SwaggerUIDsl.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/SwaggerUIDsl.kt
@@ -14,6 +14,11 @@ class SwaggerUIDsl {
     var swaggerUrl: String = "swagger-ui"
 
     /**
+     * the path under which the KTOR app gets deployed. can be useful if reverse proxy is in use.
+     */
+    var rootHostPath: String = ""
+
+    /**
      * The name of the authentication to use for the swagger routes. Null to not protect the swagger-ui.
      */
     var authentication: String? = null

--- a/src/test/kotlin/io/github/smiley4/ktorswaggerui/examples/CompletePluginConfigExample.kt
+++ b/src/test/kotlin/io/github/smiley4/ktorswaggerui/examples/CompletePluginConfigExample.kt
@@ -35,6 +35,7 @@ private fun Application.myModule() {
         swagger {
             forwardRoot = false
             swaggerUrl = "/api/swagger-ui"
+            rootHostPath = "/my-ktor-web-app"
             authentication = "SwaggerAuth"
             disableSpecValidator()
             displayOperationId = true


### PR DESCRIPTION
I made an adjustment so i can host my app behind a reverse proxy with a custom context path. Without this, i have the problem, that the routing to the SwaggerUI module is broken and the api.json file can't be found.