### PR TITLE
feat: bump victools to 4.33.1 and inline nullable schemas by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     val swaggerParserVersion = "2.1.19"
     implementation("io.swagger.parser.v3:swagger-parser:$swaggerParserVersion")
 
-    val jsonSchemaGeneratorVersion = "4.32.0"
+    val jsonSchemaGeneratorVersion = "4.33.1"
     implementation("com.github.victools:jsonschema-generator:$jsonSchemaGeneratorVersion")
     implementation("com.github.victools:jsonschema-module-jackson:$jsonSchemaGeneratorVersion")
     implementation("com.github.victools:jsonschema-module-swagger-2:$jsonSchemaGeneratorVersion")

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/data/EncodingData.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/data/EncodingData.kt
@@ -87,6 +87,7 @@ data class EncodingData(
                 .with(Option.ALLOF_CLEANUP_AT_THE_END)
                 .with(Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES)
                 .with(Option.DEFINITIONS_FOR_ALL_OBJECTS)
+                .with(Option.INLINE_NULLABLE_SCHEMAS)
                 .without(Option.INLINE_ALL_SCHEMAS)
                 .also {
                     it.forTypesInGeneral()


### PR DESCRIPTION
#83

The bump of the `jsonSchemaGeneratorVersion` is to allow usage of `Option.INLINE_NULLABLE_SCHEMAS` (added in 4.33.0). It seems reasonable to me to inline nullable schemas by default.