### PR TITLE
support swagger use session-cookie with CORS

### DIFF
--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/data/SwaggerUIData.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/data/SwaggerUIData.kt
@@ -9,7 +9,8 @@ data class SwaggerUIData(
     val displayOperationId: Boolean,
     val showTagFilterInput: Boolean,
     val sort: SwaggerUiSort,
-    val syntaxHighlight: SwaggerUiSyntaxHighlight
+    val syntaxHighlight: SwaggerUiSyntaxHighlight,
+    val withCredentials: Boolean,
 ) {
 
     companion object {
@@ -22,7 +23,8 @@ data class SwaggerUIData(
             displayOperationId = false,
             showTagFilterInput = false,
             sort = SwaggerUiSort.NONE,
-            syntaxHighlight = SwaggerUiSyntaxHighlight.AGATE
+            syntaxHighlight = SwaggerUiSyntaxHighlight.AGATE,
+            withCredentials = false,
         )
     }
 

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/SwaggerUIDsl.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/SwaggerUIDsl.kt
@@ -80,6 +80,10 @@ class SwaggerUIDsl {
      */
     var syntaxHighlight = SwaggerUIData.DEFAULT.syntaxHighlight
 
+    /**
+     * Bring cookies when initiating network requests
+     */
+    var withCredentials: Boolean = false
 
     internal fun build(base: SwaggerUIData): SwaggerUIData {
         return SwaggerUIData(
@@ -91,7 +95,8 @@ class SwaggerUIDsl {
             displayOperationId = mergeBoolean(base.displayOperationId, this.displayOperationId),
             showTagFilterInput = mergeBoolean(base.showTagFilterInput, this.showTagFilterInput),
             sort = mergeDefault(base.sort, this.sort, SwaggerUIData.DEFAULT.sort),
-            syntaxHighlight = mergeDefault(base.syntaxHighlight, this.syntaxHighlight, SwaggerUIData.DEFAULT.syntaxHighlight)
+            syntaxHighlight = mergeDefault(base.syntaxHighlight, this.syntaxHighlight, SwaggerUIData.DEFAULT.syntaxHighlight),
+            withCredentials = base.withCredentials
         )
     }
 

--- a/src/main/kotlin/io/github/smiley4/ktorswaggerui/routing/SwaggerController.kt
+++ b/src/main/kotlin/io/github/smiley4/ktorswaggerui/routing/SwaggerController.kt
@@ -86,6 +86,7 @@ class SwaggerController(
 				  SwaggerUIBundle.plugins.DownloadUrl
 				],
 				layout: "StandaloneLayout",
+				withCredentials: ${swaggerUiConfig.withCredentials},
 				$propValidatorUrl,
   				$propDisplayOperationId,
     		    $propFilter,


### PR DESCRIPTION
Let Swagger `fetch` the information in Cookie

read [withCredentials](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#withCredentials)