### PR TITLE
Fix security examples not generated with correct type

### DIFF
--- a/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/builder/example/ExampleContextImpl.kt
+++ b/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/builder/example/ExampleContextImpl.kt
@@ -21,9 +21,11 @@ class ExampleContextImpl(private val encoder: ExampleEncoder?) : ExampleContext 
             val example = generateExample(exampleDescriptor, null)
             componentExamples[exampleDescriptor.name] = example
         }
-        config.securityExamples.forEach { exampleDescriptor ->
-            val example = generateExample(exampleDescriptor, null)
-            rootExamples[exampleDescriptor] = example
+        config.securityExamples?.let {
+            it.examples.forEach { exampleDescriptor ->
+                val example = generateExample(exampleDescriptor, it.type)
+                rootExamples[exampleDescriptor] = example
+            }
         }
     }
 

--- a/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/data/ExampleConfigData.kt
+++ b/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/data/ExampleConfigData.kt
@@ -8,14 +8,14 @@ typealias ExampleEncoder = (type: TypeDescriptor?, example: Any?) -> Any?
 
 class ExampleConfigData(
     val sharedExamples: Map<String, ExampleDescriptor>,
-    val securityExamples: List<ExampleDescriptor>,
+    val securityExamples: OpenApiSimpleBodyData?,
     val exampleEncoder: ExampleEncoder?
 ) {
 
     companion object {
         val DEFAULT = ExampleConfigData(
             sharedExamples = emptyMap(),
-            securityExamples = emptyList(),
+            securityExamples = null,
             exampleEncoder = null
         )
     }

--- a/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/config/ExampleConfig.kt
+++ b/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/config/ExampleConfig.kt
@@ -41,10 +41,10 @@ class ExampleConfig {
         sharedExamples = sharedExamples,
         securityExamples = securityConfig.defaultUnauthorizedResponse?.body?.let {
             when (it) {
-                is OpenApiSimpleBodyData -> it.examples
-                is OpenApiMultipartBodyData -> emptyList()
+                is OpenApiSimpleBodyData -> it
+                is OpenApiMultipartBodyData -> null
             }
-        } ?: emptyList(),
+        },
         exampleEncoder = exampleEncoder
     )
 }


### PR DESCRIPTION
The body type from `defaultUnauthorizedResponse` was not used by the examples encoder, this fixes that so that examples can be correctly generated.