### PR TITLE
fix: broken resource route

### DIFF
--- a/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/routing/resources/DocumentedResourceRoutes.kt
+++ b/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/routing/resources/DocumentedResourceRoutes.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.serializer
 
 inline fun <reified T : Any> Route.get(
     noinline builder: OpenApiRoute.() -> Unit = { },
-    noinline body: suspend io.ktor.server.routing.RoutingContext.() -> Unit
+    noinline body: suspend io.ktor.server.routing.RoutingContext.(T) -> Unit
 ): Route {
     return documentation(builder) {
         resource<T> {
@@ -83,7 +83,7 @@ inline fun <reified T : Any> Route.delete(
 
 inline fun <reified T : Any> Route.patch(
     noinline builder: OpenApiRoute.() -> Unit = { },
-    noinline body: suspend io.ktor.server.routing.RoutingContext.() -> Unit
+    noinline body: suspend io.ktor.server.routing.RoutingContext.(T) -> Unit
 ): Route {
     return documentation(builder) {
         resource<T> {
@@ -100,7 +100,7 @@ inline fun <reified T : Any> Route.patch(
 
 inline fun <reified T : Any> Route.options(
     noinline builder: OpenApiRoute.() -> Unit = { },
-    noinline body: suspend io.ktor.server.routing.RoutingContext.() -> Unit
+    noinline body: suspend io.ktor.server.routing.RoutingContext.(T) -> Unit
 ): Route {
     return documentation(builder) {
         resource<T> {
@@ -117,7 +117,7 @@ inline fun <reified T : Any> Route.options(
 
 inline fun <reified T : Any> Route.head(
     noinline builder: OpenApiRoute.() -> Unit = { },
-    noinline body: suspend io.ktor.server.routing.RoutingContext.() -> Unit
+    noinline body: suspend io.ktor.server.routing.RoutingContext.(T) -> Unit
 ): Route {
     return documentation(builder) {
         resource<T> {

--- a/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/routing/resources/DocumentedResourceRoutes.kt
+++ b/ktor-swagger-ui/src/main/kotlin/io/github/smiley4/ktorswaggerui/dsl/routing/resources/DocumentedResourceRoutes.kt
@@ -4,8 +4,10 @@ import io.github.smiley4.ktorswaggerui.dsl.routes.OpenApiRoute
 import io.github.smiley4.ktorswaggerui.dsl.routing.documentation
 import io.github.smiley4.ktorswaggerui.dsl.routing.method
 import io.ktor.http.HttpMethod
-import io.ktor.server.resources.resource
+import io.ktor.server.resources.*
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.RoutingContext
+import kotlinx.serialization.serializer
 
 //============================//
 //             GET            //
@@ -30,7 +32,7 @@ inline fun <reified T : Any> Route.get(
 
 inline fun <reified T : Any> Route.post(
     noinline builder: OpenApiRoute.() -> Unit = { },
-    noinline body: suspend io.ktor.server.routing.RoutingContext.() -> Unit
+    noinline body: suspend io.ktor.server.routing.RoutingContext.(T) -> Unit
 ): Route {
     return documentation(builder) {
         resource<T> {
@@ -47,7 +49,7 @@ inline fun <reified T : Any> Route.post(
 
 inline fun <reified T : Any> Route.put(
     noinline builder: OpenApiRoute.() -> Unit = { },
-    noinline body: suspend io.ktor.server.routing.RoutingContext.() -> Unit
+    noinline body: suspend io.ktor.server.routing.RoutingContext.(T) -> Unit
 ): Route {
     return documentation(builder) {
         resource<T> {
@@ -64,7 +66,7 @@ inline fun <reified T : Any> Route.put(
 
 inline fun <reified T : Any> Route.delete(
     noinline builder: OpenApiRoute.() -> Unit = { },
-    noinline body: suspend io.ktor.server.routing.RoutingContext.() -> Unit
+    noinline body: suspend io.ktor.server.routing.RoutingContext.(T) -> Unit
 ): Route {
     return documentation(builder) {
         resource<T> {
@@ -124,4 +126,12 @@ inline fun <reified T : Any> Route.head(
             }
         }
     }
+}
+
+
+public inline fun <reified T : Any> Route.handle(
+    noinline body: suspend RoutingContext.(T) -> Unit
+) {
+    val serializer = serializer<T>()
+    handle(serializer, body)
 }


### PR DESCRIPTION
broken Resource route caused by importing only 

```kt
io.ktor.server.resources.resource
```

should be like this

```kt
io.ktor.server.resources.*
```