### PR TITLE
Open up internal libraries for external usage

### DIFF
--- a/ktor-swagger-ui/build.gradle.kts
+++ b/ktor-swagger-ui/build.gradle.kts
@@ -41,9 +41,9 @@ dependencies {
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$versionJackson")
 
-    implementation("io.github.smiley4:schema-kenerator-core:$versionSchemaKenerator")
-    implementation("io.github.smiley4:schema-kenerator-reflection:$versionSchemaKenerator")
-    implementation("io.github.smiley4:schema-kenerator-swagger:$versionSchemaKenerator")
+    api("io.github.smiley4:schema-kenerator-core:$versionSchemaKenerator")
+    api("io.github.smiley4:schema-kenerator-reflection:$versionSchemaKenerator")
+    api("io.github.smiley4:schema-kenerator-swagger:$versionSchemaKenerator")
 
     implementation("io.github.oshai:kotlin-logging-jvm:$versionKotlinLogging")
 


### PR DESCRIPTION
As written in the wiki here: https://github.com/SMILEY4/ktor-swagger-ui/wiki/Types-and-Schemas#global-types-and-schemas

I should be able to overwrite schemas as the following: 
```kotlin
schema("example-schema-3", Schema<Any>().also {
  it.type = "array"
  //...
})
```

But because of `Schema` is coming from `swagger-core` it's not available for me to use in my project.