### PR TITLE
Fix ExampleEncoder.kotlinx()

### DIFF
--- a/ktor-openapi/build.gradle.kts
+++ b/ktor-openapi/build.gradle.kts
@@ -60,6 +60,9 @@ dependencies {
     val versionMockk: String by project
     testImplementation("io.mockk:mockk:$versionMockk")
 
+    val versionLogback: String by project
+    testImplementation("ch.qos.logback:logback-classic:$versionLogback")
+
 }
 
 kotlin {

--- a/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/config/ExampleEncoder.kt
+++ b/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/config/ExampleEncoder.kt
@@ -1,7 +1,5 @@
 package io.github.smiley4.ktoropenapi.config
 
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.github.smiley4.ktoropenapi.config.descriptors.KTypeDescriptor
 import io.github.smiley4.ktoropenapi.config.descriptors.TypeDescriptor
 import kotlinx.serialization.json.Json
@@ -31,9 +29,8 @@ object ExampleEncoder {
         when(type) {
             is KTypeDescriptor -> {
                 val jsonEncoder = json ?: Json
-                val jsonString = jsonEncoder.encodeToString(serializer(type.type), example)
-                val jsonObj = jacksonObjectMapper().readValue(jsonString, object : TypeReference<Any>() {})
-                jsonObj
+                val serializer = jsonEncoder.serializersModule.serializer(type.type)
+                jsonEncoder.encodeToString(serializer, example)
             }
             else -> example
         }

--- a/ktor-openapi/src/test/kotlin/io/github/smiley4/ktorswaggerui/misc/ExampleEncoderTest.kt
+++ b/ktor-openapi/src/test/kotlin/io/github/smiley4/ktorswaggerui/misc/ExampleEncoderTest.kt
@@ -1,0 +1,71 @@
+package io.github.smiley4.ktorswaggerui.misc
+
+import io.github.smiley4.ktoropenapi.OpenApi
+import io.github.smiley4.ktoropenapi.config.ExampleEncoder
+import io.github.smiley4.ktoropenapi.get
+import io.github.smiley4.ktoropenapi.openApi
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.route
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+
+class ExampleEncoderTest : StringSpec({
+
+    val json = Json {
+        classDiscriminator = "_type"
+        serializersModule = SerializersModule {
+            contextual(LocalDate::class, object : KSerializer<LocalDate> {
+                private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+                override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
+                override fun deserialize(decoder: Decoder) = LocalDate.parse(decoder.decodeString(), formatter)
+                override fun serialize(encoder: Encoder, value: LocalDate) = encoder.encodeString(formatter.format(value))
+            })
+        }
+    }
+
+    "ExampleEncoder.kotlinx should not fail with contextual type" {
+        testApplication {
+            install(OpenApi) {
+                examples {
+                    encoder(ExampleEncoder.kotlinx(json))
+                }
+            }
+            routing {
+                route("api.yml") {
+                    openApi()
+                }
+
+                get("test", {
+                    response {
+                        HttpStatusCode.OK to {
+                            body<LocalDate> {
+                                example("example") {
+                                    value = LocalDate.of(2025, 12, 9)
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    call.respond(HttpStatusCode.OK)
+                }
+            }
+
+            createClient {}.get("api.yml").bodyAsText() shouldNotBe "{}"
+        }
+    }
+})


### PR DESCRIPTION
When using `ExampleEncoder.kotlinx()` with a provided `Json` instance, the method used `EmptySerializersModule()` to generate examples instead of the `serializersModule` configured in the passed `Json`. This caused:
- generation errors when contextual types were used
- potentially incorrect model representation when polymorphic types were involved

I fixed `ExampleEncoder.kotlinx` so that it uses the `serializersModule` from the provided `Json` and removed the unnecessary repeated conversion to JSON using Jackson.

I also added a test for using a contextual type inside an example block. I couldn’t find an example of a test where I could check the contents of `api.yml`, so I just verified that the configuration is created successfully.
