### PR TITLE
added 3_0 fallback

### DIFF
--- a/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/builder/OpenApiSpecBuilder.kt
+++ b/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/builder/OpenApiSpecBuilder.kt
@@ -97,9 +97,11 @@ internal class OpenApiSpecBuilder {
 
     /**
      * Transforms all schemas in the given [OpenAPI] object from OpenAPI 3.1 format to 3.0 format.
-     * The key difference is nullable handling:
-     * - 3.1 uses a type set, e.g. `types: {"string", "null"}`
-     * - 3.0 uses a single type string + a boolean flag, e.g. `type: "string", nullable: true`
+     * Handles the following differences:
+     * - Nullable: 3.1 uses a type set `types: {"string", "null"}`, 3.0 uses `type: "string", nullable: true`
+     * - Examples: 3.1 uses `examples: [val]` on schemas, 3.0 uses a single `example: val`
+     * - Exclusive bounds: 3.1 uses numeric `exclusiveMinimum`/`exclusiveMaximum`, 3.0 uses boolean flags alongside `minimum`/`maximum`
+     * - Content encoding: 3.1 uses `contentEncoding`/`contentMediaType`, 3.0 uses `format: "byte"`/`format: "binary"`
      */
     private fun transformSchemasTo30(openApi: OpenAPI) {
         val visited = mutableSetOf<Schema<*>>()
@@ -122,6 +124,9 @@ internal class OpenApiSpecBuilder {
     private fun transformSchema(schema: Schema<*>, visited: MutableSet<Schema<*>>) {
         if (!visited.add(schema)) return
         transformSchemaTypes(schema)
+        transformSchemaExamples(schema)
+        transformSchemaExclusiveBounds(schema)
+        transformSchemaContentEncoding(schema)
         schema.properties?.values?.forEach { transformSchema(it, visited) }
         schema.allOf?.forEach { transformSchema(it, visited) }
         schema.anyOf?.forEach { transformSchema(it, visited) }
@@ -152,6 +157,61 @@ internal class OpenApiSpecBuilder {
             }
         }
         schema.types = null
+    }
+
+    /**
+     * Transforms 3.1 schema-level `examples` (list) to a single 3.0 `example`.
+     * Takes the first element of the list and discards the rest.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun transformSchemaExamples(schema: Schema<*>) {
+        val examples = schema.examples ?: return
+        if (examples.isEmpty()) return
+        if (schema.example == null) {
+            (schema as Schema<Any>).example = examples.first()
+        }
+        schema.examples = null
+    }
+
+    /**
+     * Transforms 3.1 numeric `exclusiveMinimum`/`exclusiveMaximum` to 3.0 boolean flags.
+     * - 3.1: `exclusiveMinimum: 7` (a number)
+     * - 3.0: `minimum: 7, exclusiveMinimum: true`
+     */
+    private fun transformSchemaExclusiveBounds(schema: Schema<*>) {
+        schema.exclusiveMinimumValue?.let { value ->
+            if (schema.minimum == null) schema.minimum = value
+            schema.exclusiveMinimum = true
+            schema.exclusiveMinimumValue = null
+        }
+        schema.exclusiveMaximumValue?.let { value ->
+            if (schema.maximum == null) schema.maximum = value
+            schema.exclusiveMaximum = true
+            schema.exclusiveMaximumValue = null
+        }
+    }
+
+    /**
+     * Transforms 3.1 `contentEncoding`/`contentMediaType` to 3.0 `format`.
+     * - `contentEncoding: "base64"` → `format: "byte"`
+     * - `contentMediaType: <any>` → `format: "binary"`
+     */
+    private fun transformSchemaContentEncoding(schema: Schema<*>) {
+        schema.contentEncoding?.let { encoding ->
+            if (schema.format == null) {
+                schema.format = when (encoding.lowercase()) {
+                    "base64", "base64url" -> "byte"
+                    else -> null
+                }
+            }
+            schema.contentEncoding = null
+        }
+        schema.contentMediaType?.let {
+            if (schema.format == null) {
+                schema.format = "binary"
+            }
+            schema.contentMediaType = null
+        }
     }
 
     private fun builder(

--- a/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/builder/OpenApiSpecBuilder.kt
+++ b/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/builder/OpenApiSpecBuilder.kt
@@ -29,10 +29,17 @@ import io.github.smiley4.ktoropenapi.builder.openapi.WebhooksBuilder
 import io.github.smiley4.ktoropenapi.builder.route.RouteMeta
 import io.github.smiley4.ktoropenapi.builder.schema.SchemaContext
 import io.github.smiley4.ktoropenapi.builder.schema.SchemaContextImpl
+import io.github.smiley4.ktoropenapi.config.OpenApiVersion
 import io.github.smiley4.ktoropenapi.config.OutputFormat
 import io.github.smiley4.ktoropenapi.data.OpenApiPluginData
+import io.swagger.v3.core.util.Json
 import io.swagger.v3.core.util.Json31
+import io.swagger.v3.core.util.Yaml
 import io.swagger.v3.core.util.Yaml31
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.responses.ApiResponse
 
 /**
  * Builds the final openapi-specs.
@@ -74,14 +81,77 @@ internal class OpenApiSpecBuilder {
             }
             val openApi = builder(pluginConfig, schemaContext, exampleContext).build(routes)
             pluginConfig.postBuild?.let { it(openApi, specName) }
+            if (pluginConfig.openApiVersion == OpenApiVersion.V3_0) {
+                transformSchemasTo30(openApi)
+            }
+            val spec30 = pluginConfig.openApiVersion == OpenApiVersion.V3_0
             when (pluginConfig.outputFormat) {
-                OutputFormat.JSON -> Json31.pretty(openApi) to pluginConfig.outputFormat
-                OutputFormat.YAML -> Yaml31.pretty(openApi) to pluginConfig.outputFormat
+                OutputFormat.JSON -> (if (spec30) Json.pretty(openApi) else Json31.pretty(openApi)) to pluginConfig.outputFormat
+                OutputFormat.YAML -> (if (spec30) Yaml.pretty(openApi) else Yaml31.pretty(openApi)) to pluginConfig.outputFormat
             }
         } catch (e: Exception) {
             logger.error(e) { "Error during openapi-spec generation" }
             return pluginConfig.outputFormat.empty to pluginConfig.outputFormat
         }
+    }
+
+    /**
+     * Transforms all schemas in the given [OpenAPI] object from OpenAPI 3.1 format to 3.0 format.
+     * The key difference is nullable handling:
+     * - 3.1 uses a type set, e.g. `types: {"string", "null"}`
+     * - 3.0 uses a single type string + a boolean flag, e.g. `type: "string", nullable: true`
+     */
+    private fun transformSchemasTo30(openApi: OpenAPI) {
+        val visited = mutableSetOf<Schema<*>>()
+        openApi.components?.schemas?.values?.forEach { transformSchema(it, visited) }
+        openApi.paths?.values?.forEach { it.readOperations().forEach { op -> transformOperationSchemas(op, visited) } }
+        openApi.webhooks?.values?.forEach { it.readOperations().forEach { op -> transformOperationSchemas(op, visited) } }
+    }
+
+    private fun transformOperationSchemas(operation: Operation, visited: MutableSet<Schema<*>>) {
+        operation.parameters?.forEach { it.schema?.let { s -> transformSchema(s, visited) } }
+        operation.requestBody?.content?.values?.forEach { it.schema?.let { s -> transformSchema(s, visited) } }
+        operation.responses?.values?.forEach { transformResponseSchemas(it, visited) }
+    }
+
+    private fun transformResponseSchemas(response: ApiResponse, visited: MutableSet<Schema<*>>) {
+        response.content?.values?.forEach { it.schema?.let { s -> transformSchema(s, visited) } }
+        response.headers?.values?.forEach { it.schema?.let { s -> transformSchema(s, visited) } }
+    }
+
+    private fun transformSchema(schema: Schema<*>, visited: MutableSet<Schema<*>>) {
+        if (!visited.add(schema)) return
+        transformSchemaTypes(schema)
+        schema.properties?.values?.forEach { transformSchema(it, visited) }
+        schema.allOf?.forEach { transformSchema(it, visited) }
+        schema.anyOf?.forEach { transformSchema(it, visited) }
+        schema.oneOf?.forEach { transformSchema(it, visited) }
+        schema.not?.let { transformSchema(it, visited) }
+        schema.items?.let { transformSchema(it, visited) }
+        if (schema.additionalProperties is Schema<*>) {
+            transformSchema(schema.additionalProperties as Schema<*>, visited)
+        }
+    }
+
+    private fun transformSchemaTypes(schema: Schema<*>) {
+        val types = schema.types ?: return
+        if (types.isEmpty()) return
+        val nonNullTypes = types.filter { it != "null" }
+        val hasNull = types.contains("null")
+        when {
+            nonNullTypes.size == 1 -> {
+                schema.type = nonNullTypes.first()
+                if (hasNull) schema.nullable = true
+            }
+            nonNullTypes.isEmpty() -> schema.nullable = true
+            else -> {
+                // multiple non-null types: convert to anyOf
+                val anyOf = nonNullTypes.map { t -> Schema<Any>().also { it.type = t } }
+                schema.anyOf = (schema.anyOf ?: emptyList()) + anyOf
+                if (hasNull) schema.nullable = true
+            }
+        }
+        schema.types = null
     }
 
     private fun builder(

--- a/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/builder/openapi/OpenApiBuilder.kt
+++ b/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/builder/openapi/OpenApiBuilder.kt
@@ -1,6 +1,7 @@
 package io.github.smiley4.ktoropenapi.builder.openapi
 
 import io.github.smiley4.ktoropenapi.builder.example.ExampleContext
+import io.github.smiley4.ktoropenapi.config.OpenApiVersion
 import io.github.smiley4.ktoropenapi.data.OpenApiPluginData
 import io.github.smiley4.ktoropenapi.builder.route.RouteMeta
 import io.github.smiley4.ktoropenapi.builder.schema.SchemaContext
@@ -26,8 +27,8 @@ internal class OpenApiBuilder(
 
     fun build(routes: Collection<RouteMeta>): OpenAPI {
         return OpenAPI().also {
-            it.specVersion = SpecVersion.V31
-            it.openapi = "3.1.0"
+            it.specVersion = if (config.openApiVersion == OpenApiVersion.V3_0) SpecVersion.V30 else SpecVersion.V31
+            it.openapi = if (config.openApiVersion == OpenApiVersion.V3_0) "3.0.3" else "3.1.0"
             it.info = infoBuilder.build(config.info)
             it.externalDocs = externalDocumentationBuilder.build(config.externalDocs)
             it.servers = config.servers.map { server -> serverBuilder.build(server) }

--- a/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/config/OpenApiPluginConfig.kt
+++ b/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/config/OpenApiPluginConfig.kt
@@ -133,6 +133,13 @@ class OpenApiPluginConfig internal constructor() {
 
 
     /**
+     * The OpenAPI specification version to generate. Defaults to [OpenApiVersion.V3_1].
+     * Use [OpenApiVersion.V3_0] for compatibility with tools that do not yet support OpenAPI 3.1.
+     */
+    var openApiVersion: OpenApiVersion = OpenApiPluginData.DEFAULT.openApiVersion
+
+
+    /**
      * Invoked after generating the openapi-spec. Can be to e.g. further customize the spec.
      */
     var postBuild: PostBuild? = null
@@ -179,6 +186,7 @@ class OpenApiPluginConfig internal constructor() {
             specConfigs = mutableMapOf(),
             postBuild = merge(base.postBuild, postBuild),
             outputFormat = outputFormat,
+            openApiVersion = openApiVersion,
             rootPath = merge(rootPath ?: ktorRootPath, base.rootPath),
             autoDocumentResourcesRoutes = mergeBoolean(base.autoDocumentResourcesRoutes, autoDocumentResourcesRoutes),
         ).also {

--- a/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/config/OpenApiVersion.kt
+++ b/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/config/OpenApiVersion.kt
@@ -1,0 +1,17 @@
+package io.github.smiley4.ktoropenapi.config
+
+/**
+ * The OpenAPI specification version to use when generating the spec.
+ */
+enum class OpenApiVersion {
+    /**
+     * OpenAPI 3.0.x - broadly supported by most tools (Postman, AWS API Gateway, many SDKs).
+     * Nullable types are represented as `type + nullable: true` instead of a type array.
+     */
+    V3_0,
+
+    /**
+     * OpenAPI 3.1.0 - latest specification, fully aligned with JSON Schema draft 2020-12.
+     */
+    V3_1
+}

--- a/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/data/OpenApiPluginData.kt
+++ b/ktor-openapi/src/main/kotlin/io/github/smiley4/ktoropenapi/data/OpenApiPluginData.kt
@@ -1,6 +1,7 @@
 package io.github.smiley4.ktoropenapi.data
 
 import io.github.smiley4.ktoropenapi.config.OpenApiPluginConfig
+import io.github.smiley4.ktoropenapi.config.OpenApiVersion
 import io.github.smiley4.ktoropenapi.config.OutputFormat
 import io.github.smiley4.ktoropenapi.config.PathFilter
 import io.github.smiley4.ktoropenapi.config.PostBuild
@@ -25,6 +26,7 @@ internal data class OpenApiPluginData(
     val securityConfig: SecurityData,
     val tagsConfig: TagsData,
     val outputFormat: OutputFormat,
+    val openApiVersion: OpenApiVersion,
     val rootPath: String?,
     val autoDocumentResourcesRoutes: Boolean,
 ) {
@@ -45,6 +47,7 @@ internal data class OpenApiPluginData(
             securityConfig = SecurityData.DEFAULT,
             tagsConfig = TagsData.DEFAULT,
             outputFormat = OutputFormat.JSON,
+            openApiVersion = OpenApiVersion.V3_1,
             rootPath = null,
             autoDocumentResourcesRoutes = false,
         )

--- a/ktor-openapi/src/test/kotlin/io/github/smiley4/ktorswaggerui/misc/OpenApiVersionTest.kt
+++ b/ktor-openapi/src/test/kotlin/io/github/smiley4/ktorswaggerui/misc/OpenApiVersionTest.kt
@@ -1,0 +1,96 @@
+package io.github.smiley4.ktorswaggerui.misc
+
+import io.github.smiley4.ktoropenapi.OpenApi
+import io.github.smiley4.ktoropenapi.config.OpenApiVersion
+import io.github.smiley4.ktoropenapi.config.OutputFormat
+import io.github.smiley4.ktoropenapi.get
+import io.github.smiley4.ktoropenapi.openApi
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldStartWith
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.route
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+
+class OpenApiVersionTest {
+
+    /** A data class with a nullable field — triggers the "null" type in schema-kenerator output. */
+    data class NullableBody(val text: String?)
+
+    @Test
+    fun `default version is 3_1_0`() = versionTestApplication(OpenApiVersion.V3_1) { client ->
+        client.get("/api.json").also { response ->
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldStartWith "{\n  \"openapi\" : \"3.1.0\","
+        }
+    }
+
+    @Test
+    fun `v3_0 json produces version string 3_0_3`() = versionTestApplication(OpenApiVersion.V3_0) { client ->
+        client.get("/api.json").also { response ->
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldStartWith "{\n  \"openapi\" : \"3.0.3\","
+        }
+    }
+
+    @Test
+    fun `v3_0 yaml produces version string 3_0_3`() = versionTestApplication(OpenApiVersion.V3_0, OutputFormat.YAML) { client ->
+        client.get("/api.yaml").also { response ->
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldStartWith "openapi: 3.0.3\n"
+        }
+    }
+
+    @Test
+    fun `v3_0 transforms nullable property types to nullable boolean`() = versionTestApplication(OpenApiVersion.V3_0) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        // NullableBody.text is String? — after 3.0 transformation: type:"string" + nullable:true, no "null" in type arrays
+        body shouldContain "\"nullable\" : true"
+        body shouldNotContain "\"null\""
+    }
+
+    @Test
+    fun `v3_1 keeps nullable property types as type array`() = versionTestApplication(OpenApiVersion.V3_1) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        // NullableBody.text is String? — in 3.1 format: types array includes "null"
+        body shouldContain "\"null\""
+        body shouldNotContain "\"nullable\" : true"
+    }
+
+    private fun versionTestApplication(
+        version: OpenApiVersion,
+        format: OutputFormat = OutputFormat.JSON,
+        block: suspend (HttpClient) -> Unit,
+    ) {
+        testApplication {
+            val client = createClient { followRedirects = false }
+            install(OpenApi) {
+                outputFormat = format
+                openApiVersion = version
+            }
+            routing {
+                val suffix = if (format == OutputFormat.YAML) "yaml" else "json"
+                route("api.$suffix") {
+                    openApi()
+                }
+                // Route with a body type that has a nullable field, to exercise nullable schema handling
+                get("hello", {
+                    response {
+                        HttpStatusCode.OK to {
+                            body<NullableBody>()
+                        }
+                    }
+                }) {
+                    call.respondText("Hello")
+                }
+            }
+            block(client)
+        }
+    }
+}

--- a/ktor-openapi/src/test/kotlin/io/github/smiley4/ktorswaggerui/misc/OpenApiVersionTest.kt
+++ b/ktor-openapi/src/test/kotlin/io/github/smiley4/ktorswaggerui/misc/OpenApiVersionTest.kt
@@ -1,10 +1,13 @@
 package io.github.smiley4.ktorswaggerui.misc
 
 import io.github.smiley4.ktoropenapi.OpenApi
+import io.github.smiley4.ktoropenapi.config.OpenApiPluginConfig
 import io.github.smiley4.ktoropenapi.config.OpenApiVersion
 import io.github.smiley4.ktoropenapi.config.OutputFormat
 import io.github.smiley4.ktoropenapi.get
 import io.github.smiley4.ktoropenapi.openApi
+import io.github.smiley4.schemakenerator.core.annotations.ExclusiveMax
+import io.github.smiley4.schemakenerator.core.annotations.ExclusiveMin
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -16,12 +19,16 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.route
 import io.ktor.server.testing.testApplication
+import io.swagger.v3.oas.models.media.Schema
 import kotlin.test.Test
 
 class OpenApiVersionTest {
 
     /** A data class with a nullable field — triggers the "null" type in schema-kenerator output. */
     data class NullableBody(val text: String?)
+
+    /** A data class with exclusive min/max constraints — triggers exclusiveMinimumValue/exclusiveMaximumValue. */
+    data class BoundedBody(@ExclusiveMin(1) @ExclusiveMax(100) val count: Int)
 
     @Test
     fun `default version is 3_1_0`() = versionTestApplication(OpenApiVersion.V3_1) { client ->
@@ -63,9 +70,127 @@ class OpenApiVersionTest {
         body shouldNotContain "\"nullable\" : true"
     }
 
+    // --- exclusiveMinimum / exclusiveMaximum ---
+
+    @Test
+    fun `v3_0 transforms exclusiveMinimumValue to boolean flag alongside minimum`() = versionTestApplication(OpenApiVersion.V3_0) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        // BoundedBody.count has @ExclusiveMin(1) @ExclusiveMax(100)
+        // After 3.0 transform: exclusiveMinimum/Maximum are booleans, not numbers
+        body shouldContain "\"exclusiveMinimum\" : true"
+        body shouldContain "\"exclusiveMaximum\" : true"
+    }
+
+    @Test
+    fun `v3_1 keeps exclusiveMinimum as numeric value`() = versionTestApplication(OpenApiVersion.V3_1) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        // In OAS 3.1, exclusiveMinimum is a number — boolean "true" must not appear
+        body shouldNotContain "\"exclusiveMinimum\" : true"
+        body shouldNotContain "\"exclusiveMaximum\" : true"
+    }
+
+    // --- schema-level examples list ---
+
+    @Test
+    fun `v3_0 transforms schema examples list to single example`() = versionTestApplication(
+        version = OpenApiVersion.V3_0,
+        openApiConfig = {
+            postBuild = { openApi, _ ->
+                // Inject a 3.1-style examples list into all component schemas before the transform runs
+                @Suppress("UNCHECKED_CAST")
+                openApi.components?.schemas?.values?.forEach { schema ->
+                    (schema as Schema<Any>).examples = listOf("example-value")
+                }
+            }
+        }
+    ) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        // After transform: first element promoted to singular "example", list cleared.
+        // Note: "examples" : { } from components.examples (shared map) is distinct from schema-level "examples" : [...]
+        body shouldContain "\"example\" : \"example-value\""
+        body shouldNotContain "\"examples\" : ["
+    }
+
+    @Test
+    fun `v3_1 keeps schema examples list unchanged`() = versionTestApplication(
+        version = OpenApiVersion.V3_1,
+        openApiConfig = {
+            postBuild = { openApi, _ ->
+                @Suppress("UNCHECKED_CAST")
+                openApi.components?.schemas?.values?.forEach { schema ->
+                    (schema as Schema<Any>).examples = listOf("example-value")
+                }
+            }
+        }
+    ) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        // No transform in 3.1 — list is preserved as an array
+        body shouldContain "\"examples\" : ["
+        body shouldContain "\"example-value\""
+    }
+
+    // --- contentEncoding / contentMediaType ---
+
+    @Test
+    fun `v3_0 transforms contentEncoding base64 to format byte`() = versionTestApplication(
+        version = OpenApiVersion.V3_0,
+        openApiConfig = {
+            postBuild = { openApi, _ ->
+                openApi.components?.schemas?.values?.forEach { it.contentEncoding = "base64" }
+            }
+        }
+    ) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        body shouldContain "\"format\" : \"byte\""
+        body shouldNotContain "\"contentEncoding\""
+    }
+
+    @Test
+    fun `v3_1 keeps contentEncoding unchanged`() = versionTestApplication(
+        version = OpenApiVersion.V3_1,
+        openApiConfig = {
+            postBuild = { openApi, _ ->
+                openApi.components?.schemas?.values?.forEach { it.contentEncoding = "base64" }
+            }
+        }
+    ) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        body shouldContain "\"contentEncoding\" : \"base64\""
+        body shouldNotContain "\"format\" : \"byte\""
+    }
+
+    @Test
+    fun `v3_0 transforms contentMediaType to format binary`() = versionTestApplication(
+        version = OpenApiVersion.V3_0,
+        openApiConfig = {
+            postBuild = { openApi, _ ->
+                openApi.components?.schemas?.values?.forEach { it.contentMediaType = "application/octet-stream" }
+            }
+        }
+    ) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        body shouldContain "\"format\" : \"binary\""
+        body shouldNotContain "\"contentMediaType\""
+    }
+
+    @Test
+    fun `v3_1 keeps contentMediaType unchanged`() = versionTestApplication(
+        version = OpenApiVersion.V3_1,
+        openApiConfig = {
+            postBuild = { openApi, _ ->
+                openApi.components?.schemas?.values?.forEach { it.contentMediaType = "application/octet-stream" }
+            }
+        }
+    ) { client ->
+        val body = client.get("/api.json").bodyAsText()
+        body shouldContain "\"contentMediaType\" : \"application/octet-stream\""
+        body shouldNotContain "\"format\" : \"binary\""
+    }
+
     private fun versionTestApplication(
         version: OpenApiVersion,
         format: OutputFormat = OutputFormat.JSON,
+        openApiConfig: OpenApiPluginConfig.() -> Unit = {},
         block: suspend (HttpClient) -> Unit,
     ) {
         testApplication {
@@ -73,13 +198,14 @@ class OpenApiVersionTest {
             install(OpenApi) {
                 outputFormat = format
                 openApiVersion = version
+                openApiConfig()
             }
             routing {
                 val suffix = if (format == OutputFormat.YAML) "yaml" else "json"
                 route("api.$suffix") {
                     openApi()
                 }
-                // Route with a body type that has a nullable field, to exercise nullable schema handling
+                // Route with a nullable field to exercise nullable schema handling
                 get("hello", {
                     response {
                         HttpStatusCode.OK to {
@@ -88,6 +214,16 @@ class OpenApiVersionTest {
                     }
                 }) {
                     call.respondText("Hello")
+                }
+                // Route with exclusive min/max constraints to exercise exclusive bounds handling
+                get("bounded", {
+                    response {
+                        HttpStatusCode.OK to {
+                            body<BoundedBody>()
+                        }
+                    }
+                }) {
+                    call.respondText("Bounded")
                 }
             }
             block(client)


### PR DESCRIPTION
V3_0 now produces "openapi": "3.0.3"

usage:
```

install(OpenApi) {
      openApiVersion = OpenApiVersion.V3_0
  }
```